### PR TITLE
Backend - Add a filter for geography on the homepage

### DIFF
--- a/back/app/settings.py
+++ b/back/app/settings.py
@@ -33,6 +33,7 @@ ALLOWED_HOSTS = []
 INSTALLED_APPS = [
     'quickstart.apps.QuickstartConfig',
     'rest_framework',
+    'django_filters',
     'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
@@ -55,7 +56,8 @@ MIDDLEWARE = [
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 25
+    'PAGE_SIZE': 25,
+    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
 }
 
 CORS_ORIGIN_ALLOW_ALL = False

--- a/back/quickstart/views.py
+++ b/back/quickstart/views.py
@@ -57,7 +57,7 @@ class AffiliateViewSet(mixins.RetrieveModelMixin,
     filterset_fields = ['country', 'full_state', 'city']
 
     @action(detail=False, methods=['get'], url_path='countries')
-    def countries(self, request, *args):
+    def listDistinctCountries(self, request, *args):
 
         queryset = self.get_queryset()
         country_list = queryset.values_list('country', flat=True)\
@@ -66,7 +66,7 @@ class AffiliateViewSet(mixins.RetrieveModelMixin,
         return Response({"countries": country_list})
 
     @action(detail=False, methods=['get'], url_path='states')
-    def states(self, request, *args):
+    def listDistinctStates(self, request, *args):
 
         country = request.query_params.get('country', '')
         queryset = self.get_queryset()
@@ -80,7 +80,7 @@ class AffiliateViewSet(mixins.RetrieveModelMixin,
         return Response({"states": state_list})
 
     @action(detail=False, methods=['get'], url_path='cities')
-    def cities(self, request, *args):
+    def listDistinctCities(self, request, *args):
 
         country = request.query_params.get('country', '')
         if not country:

--- a/back/quickstart/views.py
+++ b/back/quickstart/views.py
@@ -60,7 +60,8 @@ class AffiliateViewSet(mixins.RetrieveModelMixin,
     def listDistinctCountries(self, request, *args):
 
         queryset = self.get_queryset()
-        country_list = queryset.values_list('country', flat=True)\
+        country_list = queryset.values_list('country', flat=True) \
+                               .order_by('country') \
                                .distinct()
 
         return Response({"countries": country_list})
@@ -71,10 +72,11 @@ class AffiliateViewSet(mixins.RetrieveModelMixin,
         country = request.query_params.get('country', '')
         queryset = self.get_queryset()
         state_list = queryset.filter(country=country)\
-                             .values_list('full_state', flat=True)\
+                             .values_list('full_state', flat=True) \
+                             .order_by('full_state') \
                              .distinct()
 
-        if state_list is None:
+        if len(state_list) < 1 or state_list[0] is None:
             state_list = []
 
         return Response({"states": state_list})
@@ -91,10 +93,11 @@ class AffiliateViewSet(mixins.RetrieveModelMixin,
 
         queryset = self.get_queryset()
         city_list = queryset.filter(query)\
-                            .values_list('city', flat=True)\
+                            .values_list('city', flat=True) \
+                            .order_by('city') \
                             .distinct()
 
-        if city_list is None:
+        if len(city_list) < 1 or city_list[0] is None:
             city_list = []
 
         return Response({"cities": city_list})

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -6,3 +6,4 @@ six==1.14.0
 sqlparse==0.3.1
 django-cors-headers==3.2.1
 requests==2.23.0
+django-filter==2.2.0


### PR DESCRIPTION
This adds three additional APIs 

- one to fetch unique countries the affiliates are located
- one to fetch unique states inside the countries the affiliates are located in
- one to fetch unique cities inside the states/countries the affiliates are located

plus some modifications to the main list operation so that list affiliates can be filtered by country, state, and city.

[ticket](https://www.notion.so/Add-a-filter-for-geography-on-the-homepage-fb0c73a08b2d4622b0db3219651a60f6)